### PR TITLE
Fix typo from DOMAINE to DOMAIN in site/docker-compose.yml

### DIFF
--- a/site/docker-compose.yml
+++ b/site/docker-compose.yml
@@ -47,13 +47,13 @@ services:
       - "traefik.enable=true"
       - "traefik.docker.network=traefik"
       # Get the routes from http
-      - "traefik.http.routers.wordpressmysite.rule=Host(`${DOMAINE}`)"
+      - "traefik.http.routers.wordpressmysite.rule=Host(`${DOMAIN}`)"
       - "traefik.http.routers.wordpressmysite.entrypoints=web"
       # Redirect these routes to https
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
       - "traefik.http.routers.wordpressmysite.middlewares=redirect-to-https@docker"
       # Get the routes from https
-      - "traefik.http.routers.wordpressmysite-secured.rule=Host(`${DOMAINE}`)"
+      - "traefik.http.routers.wordpressmysite-secured.rule=Host(`${DOMAIN}`)"
       - "traefik.http.routers.wordpressmysite-secured.entrypoints=web-secure"
       # Apply autentificiation with http challenge
       - "traefik.http.routers.wordpressmysite-secured.tls=true"


### PR DESCRIPTION
This fixes Issue #1 

Problem:
The variable ``DOMAINE`` in ``site/docker-compose.yml`` does not exist in ``site/sample.env``

Suggested solutions:
1. Either add ``DOMAINE`` in ``site/sample.env``
2. Rename ``DOMAIN`` to DOMAINE in ``site/sample.env``
3. Rename ``DOMAINE`` to ``DOMAIN`` in  ``site/docker-compose.yml``

The applied solution is 3:
I renamed the variable ``DOMAIN`` in ``site/docker-compose.yml`` as it already exists in ``site/sample.env`` and it makes grammatical sense.


